### PR TITLE
Config Management changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [puppetlabs/http-client "0.1.7"]
+                 [puppetlabs/http-client "0.2.0"]
                  [prismatic/schema "0.2.4"]
                  [com.cemerick/url "0.1.1"]
                  [cheshire "5.3.1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clj-puppetdb "0.1.1"
+(defproject clj-puppetdb "0.1.2-SNAPSHOT"
   :description "A Clojure client for the PuppetDB REST API"
-  :url "https://github.com/holguinj/clj-puppetdb"
+  :url "https://github.com/puppetlabs/clj-puppetdb"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,16 @@
   :description "A Clojure client for the PuppetDB REST API"
   :url "https://github.com/puppetlabs/clj-puppetdb"
   :license {:name "Apache License, Version 2.0"
-            :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
+            :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [puppetlabs/http-client "0.2.0"]
                  [prismatic/schema "0.2.4"]
                  [com.cemerick/url "0.1.1"]
-                 [cheshire "5.3.1"]])
+                 [cheshire "5.3.1"]]
+
+  :repl-options {:init (do (require 'spyscope.core)
+                           (use 'clj-puppetdb.testutils.repl))}
+
+  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.5"]
+                                  [ring-mock "0.1.5"]
+                                  [spyscope "0.1.5"]]}})

--- a/src/clj_puppetdb/core.clj
+++ b/src/clj_puppetdb/core.clj
@@ -1,5 +1,6 @@
 (ns clj-puppetdb.core
-  (:require [clj-puppetdb.http :refer [GET] :as http]
+  (:require [cheshire.core :as json]
+            [clj-puppetdb.http :refer [GET] :as http]
             [clj-puppetdb.paging :as paging]
             [clj-puppetdb.query :as q]
             [clj-puppetdb.schema :refer [Client]]
@@ -23,24 +24,41 @@
   
   The path argument should be a valid endpoint, e.g. \"/v4/nodes\".
 
-  The query-vec argument should be a vector representing an API query,
-  e.g. [:= [:fact \"operatingsystem\"] \"Linux\"]"
+  The query-vec argument is optional, and should be a vector representing an API query,
+  e.g. [:= [:fact \"operatingsystem\"] \"Linux\"]
+
+  The `params` map is optional, and should contain the following keys:
+  - :limit (the number of results to request)
+  - :offset (optional: the index of the first result to return, default 0)
+  - :order-by (a vector of maps, each specifying a :field and an :order key)
+  For example: `{:limit 100 :offset 0 :order-by [{:field \"value\" :order \"asc\"}]}`"
+  ([client path]
+    (query client path nil nil))
   ([client path query-vec]
-     (let [query-string (q/query->json query-vec)]
-       (GET client path {:query query-string})))
-  ([client path] (GET client path)))
+    (query client path query-vec nil))
+  ([client path query-vec paging-params]
+    (let [params (-> nil
+                     (merge
+                       (when query-vec
+                         {:query (q/query->json query-vec)}))
+                     (merge
+                       (when paging-params
+                         (update-in paging-params [:order-by] json/encode))))]
+      (if params
+        (GET client path params)
+        (GET client path)))))
 
 (defn lazy-query
   "Return a lazy sequence of results from the given query. Unlike the regular
   `query` function, `lazy-query` uses paging to fetch results gradually as they
   are consumed.
-  
+
   The `params` map is required, and should contain the following keys:
   - :limit (the number of results to request)
   - :offset (optional: the index of the first result to return, default 0)
   - :order-by (a vector of maps, each specifying a :field and an :order key)
   For example: `{:limit 100 :offset 0 :order-by [{:field \"value\" :order \"asc\"}]}`"
   ([client path params]
-     (paging/lazy-query client path params))
+    (paging/lazy-query client path params))
   ([client path query-vec params]
-     (paging/lazy-query client path query-vec params)))
+    (paging/lazy-query client path query-vec params)))

--- a/src/clj_puppetdb/core.clj
+++ b/src/clj_puppetdb/core.clj
@@ -36,16 +36,16 @@
     (query client path nil nil))
   ([client path query-vec]
     (query client path query-vec nil))
-  ([client path query-vec paging-params]
-    (let [params (-> nil
-                     (merge
-                       (when query-vec
-                         {:query (q/query->json query-vec)}))
-                     (merge
-                       (when paging-params
-                         (update-in paging-params [:order-by] json/encode))))]
-      (if params
-        (GET client path params)
+  ([client path query-vec params]
+    (let [merged-params (-> nil
+                            (merge
+                              (when query-vec
+                                {:query (q/query->json query-vec)}))
+                            (merge
+                              (when params
+                                (update-in params [:order-by] json/encode))))]
+      (if merged-params
+        (GET client path merged-params)
         (GET client path)))))
 
 (defn lazy-query

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -12,17 +12,17 @@
 
 (defn make-https-client
   [^String host {:keys [ssl-ca-cert ssl-cert ssl-key]}]
-  {:pre [(every? file? [ssl-ca-cert ssl-cert ssl-key])
-         (.startsWith host "https://")]
+  {:pre  [(every? file? [ssl-ca-cert ssl-cert ssl-key])
+          (.startsWith host "https://")]
    :post [(s/validate Client %)]}
   {:host host
    :opts {:ssl-ca-cert ssl-ca-cert
-          :ssl-cert ssl-cert
-          :ssl-key ssl-key}})
+          :ssl-cert    ssl-cert
+          :ssl-key     ssl-key}})
 
 (defn make-http-client
   [^String host]
-  {:pre [(.startsWith host "http://")]
+  {:pre  [(.startsWith host "http://")]
    :post [(s/validate Client %)]}
   {:host host
    :opts {}})
@@ -36,12 +36,13 @@
   You may provide a set of querystring parameters as a map. These will be url-encoded
   automatically and added to the path."
   ([client :- Client ^String path]
-     #_(println "GET:" path) ;; uncomment this to watch queries
-     (let [{:keys [host opts]} client]
-       (-> (http/get (str host path) (assoc opts :as :text))
-           :body
-           (json/decode keyword))))
+    #_(println "GET:" path)                                 ;; uncomment this to watch queries
+    (let [{:keys [host opts]} client
+          response (http/get (str host path) (assoc opts :as :text))]
+      [(-> response :body (json/decode keyword))
+       (if-let [total (get-in response [:headers "x-records"])]
+         {:total total})]))
   ([client path params]
-     (let [query-params (map->query params)
-           new-path (str path "?" query-params)]
-       (GET client new-path))))
+    (let [query-params (map->query params)
+          new-path (str path "?" query-params)]
+      (GET client new-path))))

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -38,11 +38,15 @@
   ([client :- Client ^String path]
     #_(println "GET:" path)                                 ;; uncomment this to watch queries
     (let [{:keys [host opts]} client
-          response (http/get (str host path) (assoc opts :as :text))]
-      [(-> response :body (json/decode keyword))
-       (if-let [total (get-in response [:headers "x-records"])]
-         {:total total})]))
+          response (http/get (str host path) (assoc opts :as :text))
+          body (-> response
+                   :body
+                   (json/decode keyword))
+          headers (:headers response)]
+      [body headers]))
   ([client path params]
-    (let [query-params (map->query params)
-          new-path (str path "?" query-params)]
-      (GET client new-path))))
+    (if (empty? params)
+      (GET client path)
+      (let [query-params (map->query params)
+            new-path (str path "?" query-params)]
+        (GET client new-path)))))

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -38,9 +38,8 @@
   ([client :- Client ^String path]
      #_(println "GET:" path) ;; uncomment this to watch queries
      (let [{:keys [host opts]} client]
-       (-> (http/get (str host path) opts)
+       (-> (http/get (str host path) (assoc opts :as :text))
            :body
-           slurp
            (json/decode keyword))))
   ([client path params]
      (let [query-params (map->query params)

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -40,6 +40,7 @@
      (let [{:keys [host opts]} client]
        (-> (http/get (str host path) opts)
            :body
+           slurp
            (json/decode keyword))))
   ([client path params]
      (let [query-params (map->query params)

--- a/test/clj_puppetdb/testutils/repl.clj
+++ b/test/clj_puppetdb/testutils/repl.clj
@@ -1,5 +1,5 @@
 (ns clj-puppetdb.testutils.repl
-  (:require [clojure.tools.namespace.repl :refer (refresh)]))
+  (:require [clojure.tools.namespace.repl :refer [refresh]]))
 
 (defn reset []
   (refresh))

--- a/test/clj_puppetdb/testutils/repl.clj
+++ b/test/clj_puppetdb/testutils/repl.clj
@@ -1,0 +1,5 @@
+(ns clj-puppetdb.testutils.repl
+  (:require [clojure.tools.namespace.repl :refer (refresh)]))
+
+(defn reset []
+  (refresh))


### PR DESCRIPTION
I've been working away in my own repo and it's added up so this PR is a bit large.

Changes in roughly the order they appear below:
- Move to http-client v0.2.0
- Update version to 0.1.2-SNAPSHOT
- Add handy repl (reset)
- Add "query-with-metadata" that gives you access to headers in the PDB response
- Update "query" to use "query-with-metadata" for DRYness
- Some unintentional formatting changes around spacing - I can revert them if they're a problem

Thanks,
S

