### PR TITLE
Support for /v4 order_by and ensure URL stability for correct VCR behaviour with nested order-by/order_by

### DIFF
--- a/src/clj_puppetdb/core.clj
+++ b/src/clj_puppetdb/core.clj
@@ -25,7 +25,7 @@
   (if (contains? params keyword)
     (if (get-in client [:opts :vcr-dir])
       ; Stability of URL is important
-      (update-in params [keyword] #(json/encode (map (fn [map] into (sorted-map) map) %)))
+      (update-in params [keyword] #(json/encode (map (fn [map] (into (sorted-map) map)) %)))
       ; Stability of URL doesn't matter
       (update-in params [keyword] json/encode))
     params))

--- a/src/clj_puppetdb/core.clj
+++ b/src/clj_puppetdb/core.clj
@@ -23,12 +23,11 @@
   "order-by params contain nested maps and if the VCR running we want to enforce a specific ordering to give us URL stability"
   [params client keyword]
   (if (contains? params keyword)
-    (update-in params [keyword]
-      (if (get-in client [:opts :vcr-dir])
-        ; Stability of URL is important
-        (fn [order-by] json/encode (map (fn [map] into (sorted-map) map) order-by))
-        ; Stability of URL doesn't matter
-        json/encode))
+    (if (get-in client [:opts :vcr-dir])
+      ; Stability of URL is important
+      (update-in params [keyword] #(json/encode (map (fn [map] into (sorted-map) map) %)))
+      ; Stability of URL doesn't matter
+      (update-in params [keyword] json/encode))
     params))
 
 (defn- encode-order-by

--- a/test/clj_puppetdb/testutils/repl.clj
+++ b/test/clj_puppetdb/testutils/repl.clj
@@ -3,3 +3,5 @@
 
 (defn reset []
   (refresh))
+
+(reset)

--- a/test/clj_puppetdb/vcr_test.clj
+++ b/test/clj_puppetdb/vcr_test.clj
@@ -41,15 +41,19 @@
                                                                conn
                                                                "/v4/nodes"
                                                                [:= :certname "test"]
-                                                               {:limit    1
-                                                                :order-by [{:field :receive-time :order "desc"}]})))
+                                                               (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
               ; Real response, but should not be recorded again
               (is (= [{:test "some-nodes"} {:total "12345"}] (query-with-metadata
                                                                conn
                                                                "/v4/nodes"
                                                                [:= :certname "test"]
-                                                               {:order-by [{:order "desc" :field :receive-time}]
-                                                                :limit    1}))))
+                                                               (array-map :order-by [(array-map :field :receive-time :order "desc")] :limit 1))))
+              ; Real response, but should not be recorded again
+              (is (= [{:test "some-nodes"} {:total "12345"}] (query-with-metadata
+                                                               conn
+                                                               "/v4/nodes"
+                                                               [:= :certname "test"]
+                                                               (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
             ; There should be 2 recordings
             (is (= 2 (count (fs/list-dir vcr-dir)))))
           (testing "and a recording already exists"
@@ -58,14 +62,12 @@
                                                              conn
                                                              "/v4/nodes"
                                                              [:= :certname "test"]
-                                                             {:limit    1
-                                                              :order-by [{:field :receive-time :order "desc"}]})))
+                                                             (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
             (is (= [{:test "some-nodes"} {:total "12345"}] (query-with-metadata
                                                              conn
                                                              "/v4/nodes"
                                                              [:= :certname "test"]
-                                                             {:order-by [{:order "desc" :field :receive-time}]
-                                                              :limit    1}))))
+                                                             (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
           (testing "and a recording already exists and the real endpoint has changed"
             (with-redefs [http/get
                           (fn [& rest]
@@ -77,14 +79,12 @@
                                                                conn
                                                                "/v4/nodes"
                                                                [:= :certname "test"]
-                                                               {:limit    1
-                                                                :order-by [{:field :receive-time :order "desc"}]})))
+                                                               (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
               (is (= [{:test "some-nodes"} {:total "12345"}] (query-with-metadata
                                                                conn
                                                                "/v4/nodes"
                                                                [:= :certname "test"]
-                                                               {:order-by [{:order "desc" :field :receive-time}]
-                                                                :limit    1}))))))
+                                                               (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))))
         (testing "when VCR is not enabled but a recording exists"
           (let [conn (connect "http://localhost:8080")]
             (is (nil? (:vcr-dir conn)))
@@ -103,14 +103,12 @@
                                                                        conn
                                                                        "/v4/nodes"
                                                                        [:= :certname "test"]
-                                                                       {:limit    1
-                                                                        :order-by [{:field :receive-time :order "desc"}]})))
+                                                                       (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
               (is (= [{:test "some-nodes-changed"} {:total "12345"}] (query-with-metadata
                                                                        conn
                                                                        "/v4/nodes"
                                                                        [:= :certname "test"]
-                                                                       {:order-by [{:order "desc" :field :receive-time}]
-                                                                        :limit    1}))))
+                                                                       (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
             ; There should still be just 2 recordings
             (is (= 2 (count (fs/list-dir vcr-dir)))))
           (fs/delete-dir vcr-dir))))))


### PR DESCRIPTION
For no obvious reason the JSON produced by encoding nested maps is stable when using {...} notation even when the input map ordering is changed. By using array-map I forced the nested map ordering to change and modified the JSON encoding to handle that scenario, just in case we see that sort of thing in the future.