### PR TITLE
closures based client & more

### DIFF
--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -1,12 +1,14 @@
 (ns clj-puppetdb.http
-  (:require [cemerick.url :refer [url-encode map->query]]
+  (:require [cemerick.url :refer [map->query]]
             [cheshire.core :as json]
             [clj-puppetdb.http-util :as util]
+            [clj-puppetdb.query :as q]
             [clj-puppetdb.schema :refer [Client]]
-            [clj-puppetdb.util :refer [file?]]
-            [clj-puppetdb.vcr :refer [vcr-get]]
-            [puppetlabs.ssl-utils.core :as ssl]
+            [clj-puppetdb.vcr :refer [make-vcr-client]]
+            [clojure.tools.logging :as log]
+            [me.raynes.fs :as fs]
             [puppetlabs.http.client.sync :as http]
+            [puppetlabs.ssl-utils.core :as ssl]
             [schema.core :as s])
   (:import [java.io IOException File]
            [javax.net.ssl SSLContext]
@@ -16,7 +18,6 @@
 ;;   - Validate schema for GET params. The GetParams schema
 ;;     exists, but needs work before it can be used.
 
-
 (def cert-keys
   "The keys to the configuration map specifying the certificates/private key
   needed for creating the SSL context.
@@ -24,47 +25,83 @@
   `puppetlabs.ssl-utils.core/pems->ssl-context` function."
   [:ssl-cert :ssl-key :ssl-ca-cert])
 
+(defn- make-client-common
+  [^String host opts]
+  (let [opts (assoc opts :as :stream)
+        info {:host host}
+        info (if-let [ssl-context (:ssl-context opts)]
+               (assoc info :ssl-context ssl-context)
+               info)]
+    (fn
+      ; This arity-overloaded variant of the function is the one called by the `GET` function.
+      ; The `this` parameter refers under normal circumstances to this very function and it is
+      ; needed to be able to call another arity-overloaded variant of the function from the
+      ; function body. When the `this` parameter refers to a different function then it
+      ; effectively overrides the other arity-overloaded variants of the function.
+      ([this path params]
+       (let [query (if (empty? params)
+                     (str host path)
+                     (str host path \? (-> params
+                                           q/params->json
+                                           map->query)))]
+         ; now call the single argument variant of the function to execute the query
+         (this query)))
+
+      ; This arity-overloaded variant of the function is the one which actually executes
+      ; the PDB query.
+      ([query]
+       (log/debug (str "GET:" query))
+       (http/get query opts))
+
+      ; This arity-overloaded variant of the function returns a map with information about
+      ; this client.
+      ([]
+       info))))
+
 (defn- make-https-client
-  [^String host {:keys [ssl-context vcr-dir] :as opts}]
-  {:pre  [(.startsWith host "https://")
-          (or (and ssl-context (or (instance? SSLContext ssl-context)
-                                   (throw (IllegalArgumentException.
-                                            (str "The ssl-context is expected to be an instance of "
-                                                 (-> SSLContext .getName)
-                                                 " but is of class "
-                                                 (-> ssl-context .getClass .getName))))))
-              (every? #(or (file? (get opts %))
-                           (throw (IllegalArgumentException.
-                                    (str "The following file does not exist: " (name %) \= (get opts %)))))
-                      cert-keys))]
-   :post [(s/validate Client %)]}
-  {:host host
-   :opts {:ssl-context (if ssl-context
-                         ssl-context
-                         (apply ssl/pems->ssl-context (map #(->> % (get opts) File.) cert-keys)))
-          :vcr-dir     vcr-dir}})
+  [^String host {:keys [ssl-context] :as opts}]
+  {:pre [(.startsWith host "https://")
+         (map? opts)
+         (or (and ssl-context (or (instance? SSLContext ssl-context)
+                                  (throw (IllegalArgumentException.
+                                           (str "The ssl-context is expected to be an instance of "
+                                                (-> SSLContext .getName)
+                                                " but is of class "
+                                                (-> ssl-context .getClass .getName))))))
+             (every? #(or (->> % (get opts) File. fs/file?)
+                          (throw (IllegalArgumentException.
+                                   (str "The following file does not exist: " (name %) \= (get opts %)))))
+                     cert-keys))]}
+  (let [opts (if ssl-context
+               opts
+               (assoc opts :ssl-context (apply ssl/pems->ssl-context (map #(->> % (get opts) File. fs/file) cert-keys))))
+        opts (apply dissoc opts cert-keys)]
+    (make-client-common host opts)))
 
 (defn- make-http-client
-  [^String host {:keys [vcr-dir]}]
-  {:pre  [(.startsWith host "http://")]
-   :post [(s/validate Client %)]}
-  {:host host
-   :opts {:vcr-dir vcr-dir}})
+  [^String host opts]
+  {:pre [(.startsWith host "http://")
+         (map? opts)]}
+  (let [opts (apply dissoc opts :ssl-context cert-keys)]
+    (make-client-common host opts)))
 
 (defn make-client
   [^String host opts]
-  {:pre [host]}
-  (cond
-    (.startsWith host "http://") (make-http-client host opts)
-    (.startsWith host "https://") (make-https-client host opts)
-    :else (throw (IllegalArgumentException. "Host must start either http:// or https://"))))
+  {:post [(s/validate Client %)]}
+  (let [vcr-dir (:vcr-dir opts)
+        opts (dissoc opts :vcr-dir)
+        client (cond
+                 (.startsWith host "http://") (make-http-client host opts)
+                 (.startsWith host "https://") (make-https-client host opts)
+                 :else (throw (IllegalArgumentException. "Host must start either http:// or https://")))]
+    (if vcr-dir
+      (make-vcr-client vcr-dir client)
+      client)))
 
-(defn- http-get
-  "Decide whether to use the VCR to service the get request"
-  [path opts vcr-dir]
-  (if vcr-dir
-    (vcr-get path opts vcr-dir)
-    (http/get path opts)))
+(defmacro assoc-kind
+  "Associate the supplied `kind` value with the :kind key in the given `exception-structure` map."
+  [exception-structure kind]
+  `(assoc ~exception-structure :kind ~kind))
 
 (defmacro catching-exceptions
   "Execute the `call` in a try-catch block, catching the named `exceptions` (or any subclasses
@@ -81,24 +118,26 @@
 (defmacro catching-parse-exceptions
   "A convenience macro for wrapping JSON parsing code. It simply delegates to the
   `catching-exceptions` macro supplying arguments to it suitable for the JSON parsing."
-  [call]
-  `(catching-exceptions ~call {:kind :puppetdb-parse-error} JsonParseException IOException))
+  [call exception-structure]
+  `(catching-exceptions
+     ~call
+     (assoc-kind ~exception-structure :puppetdb-parse-error) JsonParseException IOException))
 
 (defn- lazy-seq-catching-parse-exceptions
   "Given a lazy sequence wrap it into another lazy sequence which ensures that proper error
   handling is in place whenever an element is consumed from the sequence."
-  [result]
+  [result exception-structure]
   (lazy-seq
-    (if-let [sequence (catching-parse-exceptions (seq result))]
-      (cons (first sequence) (lazy-seq-catching-parse-exceptions (rest sequence)))
+    (if-let [sequence (catching-parse-exceptions (seq result) exception-structure)]
+      (cons (first sequence) (lazy-seq-catching-parse-exceptions (rest sequence) exception-structure))
       result)))
 
 (defn- decode-stream-catching-parse-exceptions
   "JSON decode data from given reader making sure proper error handling is in place."
-  [reader]
-  (let [result (catching-parse-exceptions (json/decode-stream reader keyword))]
+  [reader exception-structure]
+  (let [result (catching-parse-exceptions (json/decode-stream reader keyword) exception-structure)]
     (if (seq? result)
-      (lazy-seq-catching-parse-exceptions result)
+      (lazy-seq-catching-parse-exceptions result exception-structure)
       result)))
 
 (s/defn ^:always-validate GET
@@ -112,26 +151,21 @@
   automatically and added to the path."
   ([client :- Client ^String path params]
     {:pre (map? params)}
-    (let [query (if (empty? params)
-                  path
-                  (str path "?" (map->query params)))]
-      #_(println "GET:" query)                                 ;; uncomment this to watch queries
-      (let [{:keys [host opts]} client
-            vcr-dir (:vcr-dir opts)
-            opts (dissoc opts :vcr-dir)
-            response (-> (str host query)
-                         (http-get (assoc opts :as :stream) vcr-dir)
-                         (catching-exceptions {:kind :puppetdb-connection-error}))]
-        (if-not (= 200 (:status response))
-          (throw (ex-info nil {:kind   :puppetdb-query-error
-                               :url    (str host path)
-                               :msg    (slurp (util/make-response-reader response))
-                               :status (:status response)
-                               :params params})))
-        (let [data (-> response
-                       util/make-response-reader
-                       decode-stream-catching-parse-exceptions)
-              headers (:headers response)]
-          [data headers]))))
+    (let [query-info (-> (client)                           ; get client info
+                         (assoc :endpoint path)
+                         (assoc :params   params))
+          response (-> (client client path params)
+                       (catching-exceptions (assoc-kind query-info :puppetdb-connection-error)))]
+      (if-not (= 200 (:status response))
+        (throw (ex-info nil (-> query-info
+                                (assoc-kind :puppetdb-query-error)
+                                (assoc :status (:status response))
+                                (assoc :msg    (slurp (util/make-response-reader response)))))))
+      (let [data (-> response
+                     util/make-response-reader
+                     (decode-stream-catching-parse-exceptions query-info))
+            headers (:headers response)]
+        [data headers])))
+
   ([client path]
     (GET client path {})))

--- a/src/clj_puppetdb/paging.clj
+++ b/src/clj_puppetdb/paging.clj
@@ -42,18 +42,17 @@
   "Returns a map containing initial results with enough contextual data
   to request the next set of results."
   ([client path params]
-     (let [json-params (update-in params [:order-by] json/encode)
-           query-fn (fn [offset]
-                      (GET client path (assoc json-params :offset offset)))
-           limit (:limit params)
-           offset (get params :offset 0)]
-       {:body nil
-        :limit limit
-        :offset offset
-        :query query-fn}))
+   (let [limit (get params :limit)
+         offset (get params :offset 0)
+         query-fn (fn [offset]
+                    (GET client path (assoc params :offset offset)))]
+     {:body nil
+      :limit limit
+      :offset offset
+      :query query-fn}))
   ([client path query-vec params]
-     (let [params-with-query (assoc params :query (q/query->json query-vec))]
-       (lazify-query client path params-with-query))))
+   (let [params-with-query (assoc params :query (q/canonicalize-query query-vec))]
+     (lazify-query client path params-with-query))))
 
 (s/defn ^:always-validate lazy-query
   "Return a lazy sequence of results from the given query. Unlike the regular

--- a/src/clj_puppetdb/schema.clj
+++ b/src/clj_puppetdb/schema.clj
@@ -1,13 +1,11 @@
 (ns clj-puppetdb.schema
-  (:require [schema.core :refer [Any Str Int Keyword] :as s]))
+  (:require [schema.core :refer [Any Str Int Keyword] :as s])
+  (:import [clojure.lang IFn]))
 
 (def Client
-  "Schema for PuppetDB client maps. Note: doesn't check that
-  the certs (if provided) actually exist."
-  {:host Str
-   :opts (s/either {:ssl-context javax.net.ssl.SSLContext
-                    :vcr-dir     (s/maybe Str)}
-                   {:vcr-dir (s/maybe Str)})})
+  "Schema for PuppetDB client map. Note: doesn't check the
+  arity of the function."
+  IFn)
 
 (def PagingParams
   "Schema for params passed to lazy-query."

--- a/src/clj_puppetdb/util.clj
+++ b/src/clj_puppetdb/util.clj
@@ -1,8 +1,0 @@
-(ns clj-puppetdb.util
-  (:import [java.io File]))
-
-(defn file?
-  [^String f]
-  (if (nil? f)
-    false
-    (-> f File. .isFile)))

--- a/src/clj_puppetdb/vcr.clj
+++ b/src/clj_puppetdb/vcr.clj
@@ -1,15 +1,11 @@
 (ns clj-puppetdb.vcr
-  (:require [clojure.edn :as edn]
-            [clj-puppetdb.http-util :as util]
+  (:require [clj-puppetdb.http-util :as util]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [me.raynes.fs :as fs]
-            [puppetlabs.kitchensink.core :refer [utf8-string->sha1]]
-            [puppetlabs.http.client.sync :as http])
-  (:import [java.io ByteArrayInputStream FileInputStream InputStreamReader BufferedReader PushbackReader
-                    FileOutputStream OutputStreamWriter BufferedWriter]
-           [org.apache.http.entity ContentType]
-           [java.nio.charset Charset]))
-
-(def vcr-charset (Charset/forName "UTF-8"))
+            [puppetlabs.kitchensink.core :refer [utf8-string->sha1]])
+  (:import [java.io File ByteArrayInputStream InputStreamReader BufferedReader PushbackReader]
+           [org.apache.http.entity ContentType]))
 
 (defn rebuild-content-type
   "Rebuild the `:content-type` key in the given `response` map based on the value of the content-type
@@ -22,21 +18,29 @@
         (assoc response :content-type
                         {:mime-type (.getMimeType content-type)
                          :charset   (.getCharset content-type)})))))
+
 (defn body->string
   [response]
   "Turn response body into a string."
   (let [charset (util/response-charset response)]
-    (update-in response [:body] #(slurp (BufferedReader. (InputStreamReader. % charset))))))
+    (->> (-> (get response :body)
+             (InputStreamReader. charset)
+             BufferedReader.
+             slurp)
+         (assoc response :body))))
 
 (defn body->stream
   [response]
   "Turn response body into a `java.io.InputStream` subclass."
   (let [charset (util/response-charset response)]
-    (update-in response [:body] #(ByteArrayInputStream. (.getBytes % charset)))))
+    (->> (-> (get response :body)
+           (.getBytes charset)
+           ByteArrayInputStream.)
+         (assoc response :body))))
 
-(defn- vcr-filename
-  [vcr-dir path]
-  (str vcr-dir "/" (utf8-string->sha1 path) ".clj"))
+(defn- vcr-file
+  [vcr-dir query]
+  (fs/file (File. (str vcr-dir "/" (utf8-string->sha1 query) ".clj"))))
 
 (defn- vcr-serialization-transform
   "Prepare the response for searialization."
@@ -52,25 +56,66 @@
       rebuild-content-type
       body->stream))
 
-(defn vcr-get
-  "VCR-enabled version of GET that will check for a file containing a response first. If none is found
-  a real GET request is made and the response recorded for the future."
-  [path opts vcr-dir]
-  (let [file (vcr-filename vcr-dir path)]
-    (when-not (fs/exists? file)
-      (let [response (vcr-serialization-transform (http/get path opts))]
-        (fs/mkdirs (fs/parent file))
-        (-> file
-            FileOutputStream.
-            (OutputStreamWriter. vcr-charset)
-            BufferedWriter.
-            (spit response))))
-    ; Always read from the file - even if we just wrote it - to fast-fail on serialization errors
-    ; (at the expense of performance)
-    (-> (with-open [reader (-> file
-                               FileInputStream.
-                               (InputStreamReader. vcr-charset)
-                               BufferedReader.
-                               PushbackReader.)]
-          (edn/read reader))
-        vcr-unserialization-transform)))
+(def nested-params
+  "parameters which contain nested maps"
+  ; TODO remove :order-by when we drop support for PDB API older than v4
+  [:order_by :order-by])
+
+(defn- normalize-params
+  "certain parmas (notably order_by) contain nested maps and if the VCR is running we want to
+  enforce a specific ordering to give us URL stability"
+  [params]
+  (reduce
+    (fn [params key]
+      (if (contains? params key)
+        (->> (get params key)
+             (map #(into (sorted-map) %))
+             (assoc params key))
+        params))
+    params
+    nested-params))
+
+(defn make-vcr-client
+  "Make VCR-enabled version of the supplied `client` that will check for a file containing
+  a response first. If none is found the original client is called to obtain the response,
+  which is then recorded for the future."
+  [vcr-dir client]
+  (fn
+    ; This arity-overloaded variant of the function sorts the known nested structures in the
+    ; query parameters to give us URL stability and then delegates to the original client.
+    ; Note that under normal circumstances the `this` parameter points to this very function
+    ; but when it is passed to the original client, it effectively overrides the other
+    ; arity-overloaded variants of the function for the client - i.e. it makes the client
+    ; call our versions of the arity-overloaded variants of the function.
+    ([this path params]
+     (->> params
+          normalize-params
+          (client this path)))
+
+    ; This arity-overloaded variant of the function is called from the original client (thanks
+    ; to the override effect described above) to actually execute the PDB query.
+    ; It first tries to find a response for the query recorded in a file and only delegates to
+    ; the original client if no recorded response for the query is found.
+    ([query]
+     (let [file (vcr-file vcr-dir query)]
+       (when-not (fs/exists? file)
+         (let [response (-> query
+                            client
+                            vcr-serialization-transform)]
+           (fs/mkdirs (fs/parent file))
+           (-> file
+               io/writer
+               (spit response))))
+       ; Always read from the file - even if we just wrote it - to fast-fail on serialization errors
+       ; (at the expense of performance)
+       (-> (with-open [reader (-> file
+                                  io/reader
+                                  PushbackReader.)]
+             (edn/read reader))
+           vcr-unserialization-transform)))
+
+    ; This arity-overloaded variant of the function just adds the vcr-dir info to the info map
+    ; returned by the original client.
+    ([]
+     (-> (client)
+         (assoc :vcr-dir vcr-dir)))))

--- a/test/clj_puppetdb/core_test.clj
+++ b/test/clj_puppetdb/core_test.clj
@@ -5,15 +5,14 @@
 (deftest connect-test
   (testing "Should create a connection with http://localhost:8080 with no additional arguments"
     (let [conn (connect "http://localhost:8080")]
-      (is (= conn {:host "http://localhost:8080" :opts {:vcr-dir nil}}))))
+      (is (= (conn) {:host "http://localhost:8080"}))))
   (testing "Should create a connection with http://localhost:8080 and VCR enabled"
     (let [conn (connect "http://localhost:8080" {:vcr-dir "/temp"})]
-      (is (= conn {:host "http://localhost:8080" :opts {:vcr-dir "/temp"}}))))
+      (is (= (conn) {:host "http://localhost:8080" :vcr-dir "/temp"}))))
   (testing "Should accept https://puppetdb:8081 with a map of test certs"
     (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
                 :ssl-cert    "./dev-resources/certs/cert.pem"
-                :ssl-key     "./dev-resources/certs/key.pem"
-                :vcr-dir     nil}
+                :ssl-key     "./dev-resources/certs/key.pem"}
           conn (connect "https://puppetdb:8081" opts)]
       ;; I'm only testing for truthiness of conn here. Schema validation should handle the rest,
       ;; and testing equality with java.io.File objects doesn't seem to work.
@@ -27,4 +26,4 @@
       ;; I'm testing for truthiness of conn here. Schema validation should handle the rest except the VCR piece,
       ;; and testing equality with java.io.File objects doesn't seem to work.
       (is conn)
-      (is (= "/temp" (get-in conn [:opts :vcr-dir]))))))
+      (is (= "/temp" (get (conn) :vcr-dir))))))

--- a/test/clj_puppetdb/query_test.clj
+++ b/test/clj_puppetdb/query_test.clj
@@ -1,15 +1,15 @@
 (ns clj-puppetdb.query-test
   (:require [clojure.test :refer :all]
-            [clj-puppetdb.query :refer [query->json]]))
+            [clj-puppetdb.query :refer [canonicalize-query]]))
 
-(deftest query->json-test
+(deftest canonicalize-query-test
   (testing "The dreaded ~ operator"
-    (is (= (query->json [:match :certname #"web\d+"])
-           (query->json ["~" :certname #"web\d+"])
-           "[\"~\",\"certname\",\"web\\\\d+\"]")))
+    (is (= (canonicalize-query [:match :certname #"web\d+"])
+           (canonicalize-query ["~" :certname #"web\d+"])
+           ["~" :certname "web\\d+"])))
   (testing "Nested expressions"
-    (is (= (query->json [:>= [:fact "uptime_days"] 10])
-           "[\">=\",[\"fact\",\"uptime_days\"],10]")))
+    (is (= (canonicalize-query [:>= [:fact "uptime_days"] 10])
+           [:>= [:fact "uptime_days"] 10])))
   (testing "Booleans don't get converted to strings"
-    (is (= (query->json [:= [:fact "is_virtual"] false])
-           "[\"=\",[\"fact\",\"is_virtual\"],false]"))))
+    (is (= (canonicalize-query [:= [:fact "is_virtual"] false])
+           [:= [:fact "is_virtual"] false]))))

--- a/test/clj_puppetdb/vcr_test.clj
+++ b/test/clj_puppetdb/vcr_test.clj
@@ -26,7 +26,7 @@
       (fs/delete-dir vcr-dir)
       (testing "when VCR is enabled"
         (let [conn (connect "http://localhost:8080" {:vcr-dir vcr-dir})]
-          (is (= vcr-dir (get-in conn [:opts :vcr-dir])))
+          (is (= vcr-dir (:vcr-dir (conn))))
           (testing "and no recording exists"
             (with-redefs [http/get
                           (fn [& _]
@@ -93,7 +93,7 @@
                                                              (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))))
         (testing "when VCR is not enabled but a recording exists"
           (let [conn (connect "http://localhost:8080")]
-            (is (nil? (:vcr-dir conn)))
+            (is (not (contains? (conn) :vcr-dir)))
             (with-redefs [http/get
                           (fn [& _]
                             ; Return mock data


### PR DESCRIPTION
This was supposed to be a really small PR - I just wanted to add JSON encoding for the ```counts_filter``` parameter (there are in total 3 parameters which need JSON encoding: ```query```, ```order_by```, ```counts_filter```) - but ended up quite big including turning the client map object into a function reference, which is further complicated by the fact that I introduce a kind of polymorphism as known in OO programing with that function.