### PR TITLE
(PE-8559) clj-puppetdb timeout on missing PDB server is very long - adde...

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,30 @@ Both HTTP and HTTPS connections are supported.
 
 #### Create a new connection without SSL
 
-The `clj-puppetdb.core/connect` function minimally requires a host URL, including the protocol and port:
+The `clj-puppetdb.core/connect` function minimally requires a host URL, including the protocol and port. An optional parameter map may be provided:
 
 ```clojure
 (ns clj-puppetdb.ssl-example
   (:require [clj-puppetdb.core :as pdb]
             [clojure.java.io :as io]))
 
-(def client (pdb/connect "http://puppetdb:8080"))
+(def client (pdb/connect "http://puppetdb:8080" {:connect-timeout-milliseconds 5000}))
 ```
+The following options are supported on both secure and unsecure connections alike:
 
-If you're connecting over plain HTTP, no other options are supported.
+* `:connect-timeout-milliseconds`: maximum number of milliseconds that the
+  client will wait for a connection to be established.  A value of 0 is
+  interpreted as infinite.  A negative value or the absence of this option
+  is interpreted as undefined (system default).
+* `:socket-timeout-milliseconds`: maximum number of milliseconds that the
+  client will allow for no data to be available on the socket before closing the
+  underlying connection, 'SO_TIMEOUT' in socket terms.  A timeout of zero is
+  interpreted as an infinite timeout.  A negative value or the absence of
+  this setting is interpreted as undefined (system default).
 
 #### Create a new connection with SSL (using Puppet's certificates)
 
-If you want to connect to PuppetDB more securely, clj-puppetdb supports using SSL certificates. If you're running clj-puppetdb from a node that's managed by Puppet, you'll already have the certificates you need. Just supply them in a map after the host URL:
+If you want to connect to PuppetDB more securely, clj-puppetdb supports using SSL certificates. If you're running clj-puppetdb from a node that's managed by Puppet, you'll already have the certificates you need. Just supply them in a map (merged with the connection parameters) after the host URL:
 
 ```clojure
 (ns clj-puppetdb.ssl-example

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [com.cemerick/url "0.1.1"]
                  [me.raynes/fs "1.4.5"]
                  [prismatic/schema "0.2.2"]
-                 [puppetlabs/http-client "0.4.2"]
+                 [puppetlabs/http-client "0.4.3"]
                  [puppetlabs/kitchensink "1.0.0"]]
   :plugins [[lein-release "1.0.5"]]
   :lein-release {:scm        :git

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -25,13 +25,14 @@
   `puppetlabs.ssl-utils.core/pems->ssl-context` function."
   [:ssl-cert :ssl-key :ssl-ca-cert])
 
+(def connection-relevant-opts
+  [:ssl-context :connect-timeout-milliseconds :socket-timeout-milliseconds])
+
 (defn- make-client-common
   [^String host opts]
   (let [opts (assoc opts :as :stream)
-        info {:host host}
-        info (if-let [ssl-context (:ssl-context opts)]
-               (assoc info :ssl-context ssl-context)
-               info)]
+        info (select-keys opts connection-relevant-opts)
+        info (assoc info :host host)]
     (fn
       ; This arity-overloaded variant of the function is the one called by the `GET` function.
       ; The `this` parameter refers under normal circumstances to this very function and it is


### PR DESCRIPTION
...d connect/socket timeout parameters

The new clj-http-client library (0.4.3+) allows for a connection and socket timeout. To make use of these new additions we must allow these parameters through this library.