### PR TITLE
(PE-12407) use constant PDB base URL in VCR file names computations

### DIFF
--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -151,8 +151,8 @@
 
   You may provide a set of querystring parameters as a map. These will be url-encoded
   automatically and added to the path."
-  ([^PdbClient client ^String path params]
-    {:pre (map? params)}
+  ([client path params]
+    {:pre [(satisfies? PdbClient client) (instance? String path) (map? params)]}
     (let [query-info (-> (client-info client)
                          (assoc :endpoint path)
                          (assoc :params   params))


### PR DESCRIPTION
Previously the VCR file names were computed from the entire URLs corresponding to the PDB queries submitted by the clients - including the PuppetDB instance base URL. This was wrong as it made it impossible to record VCR data talking to a PDB instance at one URL base - say ```http://localhost:8080``` and use them when trying to access PDB instance at another URL - say ```https://puppetdb:8081```.
Newly the VCR file name computations use URLs where the PDB base URL is replaced with a static value, thus avoiding the above described problem.