### PR TITLE
(PE-10513) Picking up unbuffered HTTP streaming in CM

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,8 +11,8 @@
                  [cheshire "5.4.0"]
                  [com.cemerick/url "0.1.1"]
                  [me.raynes/fs "1.4.5"]
-                 [prismatic/schema "0.2.2"]
-                 [puppetlabs/http-client "0.4.3"]
+                 [puppetlabs/http-client "0.4.5"]
+                 [prismatic/schema "0.4.0"]
                  [puppetlabs/kitchensink "1.0.0"]]
   :plugins [[lein-release "1.0.5"]]
   :lein-release {:scm        :git

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -6,7 +6,8 @@
             [clj-puppetdb.vcr :refer [make-vcr-client]]
             [clojure.tools.logging :as log]
             [me.raynes.fs :as fs]
-            [puppetlabs.http.client.sync :as http]
+            [puppetlabs.http.client.async :as http-async]
+            [puppetlabs.http.client.common :as http-common]
             [puppetlabs.ssl-utils.core :as ssl]
             [schema.core :as s])
   (:import [java.io IOException File]
@@ -29,9 +30,9 @@
 
 (defn- make-client-common
   [^String host opts]
-  (let [opts (assoc opts :as :stream)
-        info (select-keys opts connection-relevant-opts)
-        info (assoc info :host host)]
+  (let [conn-opts (select-keys opts connection-relevant-opts)
+        req-opts (apply dissoc opts connection-relevant-opts)
+        pdb-client (http-async/create-client conn-opts)]
     (reify
       PdbClient
       (pdb-get [this path params]
@@ -47,10 +48,10 @@
 
       (pdb-do-get [_ query]
         (log/debug (str "GET:" query))
-        (http/get query opts))
+        @(http-common/get pdb-client query req-opts))
 
       (client-info [_]
-        info))))
+        (assoc conn-opts :host host)))))
 
 (defn- file?
   [^String file-path]

--- a/test/clj_puppetdb/vcr_test.clj
+++ b/test/clj_puppetdb/vcr_test.clj
@@ -4,21 +4,21 @@
             [clj-puppetdb.http-core :refer :all]
             [clj-puppetdb.http :refer :all]
             [clj-puppetdb.vcr :as vcr]
-            [puppetlabs.http.client.sync :as http]
+            [puppetlabs.http.client.async :as async]
             [me.raynes.fs :as fs]))
 
 (def mock-http-response-template
-  (-> {:opts                  {:persistent      false
-                               :as              :stream
-                               :decompress-body true
-                               :body            nil
-                               :headers         {}
-                               :method          :get
-                               :url             "http://pe:8080/v4/nodes"}
+  (-> {:opts {:persistent false
+              :as :stream
+              :decompress-body true
+              :body nil
+              :headers {}
+              :method :get
+              :url "http://pe:8080/v4/nodes"}
        :orig-content-encoding "gzip"
-       :status                200
-       :headers               {"x-records" "12345"
-                               "content-type" "application/json; charset=iso-8859-1"}}
+       :status 200
+       :headers {"x-records" "12345"
+                 "content-type" "application/json; charset=iso-8859-1"}}
       vcr/rebuild-content-type))
 
 (deftest vcr-test
@@ -29,97 +29,97 @@
         (let [conn (connect "http://localhost:8080" {:vcr-dir vcr-dir})]
           (is (= vcr-dir (:vcr-dir (client-info conn))))
           (testing "and no recording exists"
-            (with-redefs [http/get
-                          (fn [& _]
-                            ; Return mock data
-                            (-> mock-http-response-template
-                                (assoc :body " {\"test\": \"all-nodes\"} ")
-                                vcr/body->stream))]
+            (with-redefs [async/request-with-client
+                          (fn [_ _ _] (future
+                                       ; Return mock data
+                                       (-> mock-http-response-template
+                                           (assoc :body " {\"test\": \"all-nodes\"} ")
+                                           vcr/body->stream)))]
               ; Real response, should be recorded
               (is (= [{:test "all-nodes"} {:total 12345}] (query-with-metadata conn "/v4/nodes" nil))))
-            (with-redefs [http/get
-                          (fn [& _]
-                            ; Return mock data
-                            (-> mock-http-response-template
-                                (assoc :body " {\"test\": \"some-nodes\"} ")
-                                vcr/body->stream))]
+            (with-redefs [async/request-with-client
+                          (fn [_ _ _] (future
+                                       ; Return mock data
+                                       (-> mock-http-response-template
+                                           (assoc :body " {\"test\": \"some-nodes\"} ")
+                                           vcr/body->stream)))]
               ; Real response, should be recorded
               (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                             conn
-                                                             "/v4/nodes"
-                                                             [:= :certname "test"]
-                                                             (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
+                                                            conn
+                                                            "/v4/nodes"
+                                                            [:= :certname "test"]
+                                                            (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
               ; Real response, but should not be recorded again
               (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                             conn
-                                                             "/v4/nodes"
-                                                             [:= :certname "test"]
-                                                             (array-map :order-by [(array-map :field :receive-time :order "desc")] :limit 1))))
+                                                            conn
+                                                            "/v4/nodes"
+                                                            [:= :certname "test"]
+                                                            (array-map :order-by [(array-map :field :receive-time :order "desc")] :limit 1))))
               ; Real response, but should not be recorded again
               (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                             conn
-                                                             "/v4/nodes"
-                                                             [:= :certname "test"]
-                                                             (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
+                                                            conn
+                                                            "/v4/nodes"
+                                                            [:= :certname "test"]
+                                                            (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
             ; There should be 2 recordings
             (is (= 2 (count (fs/list-dir vcr-dir)))))
           (testing "and a recording already exists"
             (is (= [{:test "all-nodes"} {:total 12345}] (query-with-metadata conn "/v4/nodes" nil)))
             (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                           conn
-                                                           "/v4/nodes"
-                                                           [:= :certname "test"]
-                                                           (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
+                                                          conn
+                                                          "/v4/nodes"
+                                                          [:= :certname "test"]
+                                                          (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
             (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                           conn
-                                                           "/v4/nodes"
-                                                           [:= :certname "test"]
-                                                           (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
+                                                          conn
+                                                          "/v4/nodes"
+                                                          [:= :certname "test"]
+                                                          (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
           (testing "and a recording already exists and the real endpoint has changed"
-            (with-redefs [http/get
-                          (fn [& _]
+            (with-redefs [async/request-with-client
+                          (fn [_ _ _]
                             ; This should not be called as all the responses should be read from the VCR files.
                             (throw (RuntimeException. "this should actually never be called")))]
               ; VCR enabled so we expect to see the original bodies
               (is (= [{:test "all-nodes"} {:total 12345}] (query-with-metadata conn "/v4/nodes" nil)))
               (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                             conn
-                                                             "/v4/nodes"
-                                                             [:= :certname "test"]
-                                                             (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
+                                                            conn
+                                                            "/v4/nodes"
+                                                            [:= :certname "test"]
+                                                            (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
               (is (= [{:test "some-nodes"} {:total 12345}] (query-with-metadata
-                                                             conn
-                                                             "/v4/nodes"
-                                                             [:= :certname "test"]
-                                                             (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))))
+                                                            conn
+                                                            "/v4/nodes"
+                                                            [:= :certname "test"]
+                                                            (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))))
         (testing "when VCR is not enabled but a recording exists"
           (let [conn (connect "http://localhost:8080")]
             (is (not (contains? (client-info conn) :vcr-dir)))
-            (with-redefs [http/get
-                          (fn [& _]
-                            ; Return mock data
-                            (-> mock-http-response-template
-                                (assoc :body " {\"test\": \"all-nodes-changed\"} ")
-                                vcr/body->stream))]
+            (with-redefs [async/request-with-client
+                          (fn [_ _ _] (future
+                                       ; Return mock data
+                                       (-> mock-http-response-template
+                                           (assoc :body " {\"test\": \"all-nodes-changed\"} ")
+                                           vcr/body->stream)))]
               ; Real response, should not be recorded
               (is (= [{:test "all-nodes-changed"} {:total 12345}] (query-with-metadata conn "/v4/nodes" nil))))
-            (with-redefs [http/get
-                          (fn [& _]
-                            ; Return mock data
-                            (-> mock-http-response-template
-                                (assoc :body " {\"test\": \"some-nodes-changed\"} ")
-                                vcr/body->stream))]
+            (with-redefs [async/request-with-client
+                          (fn [_ _ _] (future
+                                       ; Return mock data
+                                       (-> mock-http-response-template
+                                           (assoc :body " {\"test\": \"some-nodes-changed\"} ")
+                                           vcr/body->stream)))]
               ; Real response, should not be recorded
               (is (= [{:test "some-nodes-changed"} {:total 12345}] (query-with-metadata
-                                                                     conn
-                                                                     "/v4/nodes"
-                                                                     [:= :certname "test"]
-                                                                     (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
+                                                                    conn
+                                                                    "/v4/nodes"
+                                                                    [:= :certname "test"]
+                                                                    (array-map :limit 1 :order-by [(array-map :field :receive-time :order "desc")]))))
               (is (= [{:test "some-nodes-changed"} {:total 12345}] (query-with-metadata
-                                                                     conn
-                                                                     "/v4/nodes"
-                                                                     [:= :certname "test"]
-                                                                     (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
+                                                                    conn
+                                                                    "/v4/nodes"
+                                                                    [:= :certname "test"]
+                                                                    (array-map :order-by [(array-map :order "desc" :field :receive-time)] :limit 1)))))
             ; There should still be just 2 recordings
             (is (= 2 (count (fs/list-dir vcr-dir)))))
           (fs/delete-dir vcr-dir))))))


### PR DESCRIPTION
Waiting for https://github.com/puppetlabs/clj-http-client/pull/42 to merge before this can go in. This change merely activates unbuffered streaming in clj-http-client. **Note: this will need an up-version in the project file for puppetlabs/http-client.**